### PR TITLE
FIx with livestream duration

### DIFF
--- a/musicbot/audiocontroller.py
+++ b/musicbot/audiocontroller.py
@@ -1,8 +1,8 @@
 import discord
-import youtube_dl
-
 import asyncio
-import concurrent.futures
+
+from concurrent.futures import ThreadPoolExecutor
+from youtube_dl import YoutubeDL
 
 from musicbot import linkutils
 from musicbot import utils
@@ -75,7 +75,7 @@ class AudioController(object):
                 conversion = self.search_youtube(await linkutils.convert_spotify(song.info.webpage_url))
                 song.info.webpage_url = conversion
 
-            downloader = youtube_dl.YoutubeDL(
+            downloader = YoutubeDL(
                 {'format': 'bestaudio', 'title': True, "cookiefile": config.COOKIE_PATH})
             r = downloader.extract_info(
                 song.info.webpage_url, download=False)
@@ -134,12 +134,12 @@ class AudioController(object):
             track = track.split("&list=")[0]
 
         try:
-            downloader = youtube_dl.YoutubeDL(
+            downloader = YoutubeDL(
                 {'format': 'bestaudio', 'title': True, "cookiefile": config.COOKIE_PATH})
             r = downloader.extract_info(
                 track, download=False)
         except:
-            downloader = youtube_dl.YoutubeDL(
+            downloader = YoutubeDL(
                 {'title': True, "cookiefile": config.COOKIE_PATH})
             r = downloader.extract_info(
                 track, download=False)
@@ -177,7 +177,7 @@ class AudioController(object):
                 "cookiefile": config.COOKIE_PATH
             }
 
-            with youtube_dl.YoutubeDL(options) as ydl:
+            with YoutubeDL(options) as ydl:
                 r = ydl.extract_info(url, download=False)
 
                 for entry in r['entries']:
@@ -202,7 +202,7 @@ class AudioController(object):
                 'format': 'bestaudio/best',
                 'extract_flat': True
             }
-            with youtube_dl.YoutubeDL(options) as ydl:
+            with YoutubeDL(options) as ydl:
                 r = ydl.extract_info(url, download=False)
 
                 for entry in r['entries']:
@@ -227,7 +227,7 @@ class AudioController(object):
             if song.host == linkutils.Sites.Spotify:
                 song.info.webpage_url = self.search_youtube(song.info.title)
 
-            downloader = youtube_dl.YoutubeDL(
+            downloader = YoutubeDL(
                 {'format': 'bestaudio', 'title': True, "cookiefile": config.COOKIE_PATH})
             r = downloader.extract_info(
                 song.info.webpage_url, download=False)
@@ -242,7 +242,7 @@ class AudioController(object):
             song.info.title = await linkutils.convert_spotify(song.info.webpage_url)
 
         loop = asyncio.get_event_loop()
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=config.MAX_SONG_PRELOAD)
+        executor = ThreadPoolExecutor(max_workers=config.MAX_SONG_PRELOAD)
         await asyncio.wait(fs={loop.run_in_executor(executor, down, song)}, return_when=asyncio.ALL_COMPLETED)
 
     def search_youtube(self, title):
@@ -259,7 +259,7 @@ class AudioController(object):
             "cookiefile": config.COOKIE_PATH
         }
 
-        with youtube_dl.YoutubeDL(options) as ydl:
+        with YoutubeDL(options) as ydl:
             r = ydl.extract_info(title, download=False)
 
         videocode = r['entries'][0]['id']

--- a/musicbot/linkutils.py
+++ b/musicbot/linkutils.py
@@ -1,24 +1,25 @@
-import aiohttp
-import re
+from aiohttp import ClientSession
 from bs4 import BeautifulSoup
+
+from spotipy import Spotify
+from spotipy.oauth2 import SpotifyClientCredentials
+
+from re import compile, search
 from enum import Enum
 from config import config
 
-import spotipy
-from spotipy.oauth2 import SpotifyClientCredentials
-
 
 try:
-    sp_api = spotipy.Spotify(auth_manager=SpotifyClientCredentials(
+    sp_api = Spotify(auth_manager=SpotifyClientCredentials(
         client_id=config.SPOTIFY_ID, client_secret=config.SPOTIFY_SECRET))
     api = True
 except:
     api = False
 
-url_regex = re.compile(
+url_regex = compile(
     "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 
-session = aiohttp.ClientSession(
+session = ClientSession(
     headers={'User-Agent': 'python-requests/2.20.0'})
 
 
@@ -32,7 +33,7 @@ def clean_sclink(track):
 
 async def convert_spotify(url):
 
-    if re.search(url_regex, url):
+    if search(url_regex, url):
         result = url_regex.search(url)
         url = result.group(0)
 
@@ -118,10 +119,10 @@ async def get_spotify_playlist(url):
 
 def get_url(content):
 
-    regex = re.compile(
+    regex = compile(
         "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 
-    if re.search(regex, content):
+    if search(regex, content):
         result = regex.search(content)
         url = result.group(0)
         return url

--- a/musicbot/linkutils.py
+++ b/musicbot/linkutils.py
@@ -1,10 +1,11 @@
+import re
+
 from aiohttp import ClientSession
 from bs4 import BeautifulSoup
 
 from spotipy import Spotify
 from spotipy.oauth2 import SpotifyClientCredentials
 
-from re import compile, search
 from enum import Enum
 from config import config
 
@@ -16,7 +17,7 @@ try:
 except:
     api = False
 
-url_regex = compile(
+url_regex = re.compile(
     "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 
 session = ClientSession(
@@ -33,7 +34,7 @@ def clean_sclink(track):
 
 async def convert_spotify(url):
 
-    if search(url_regex, url):
+    if re.search(url_regex, url):
         result = url_regex.search(url)
         url = result.group(0)
 
@@ -119,10 +120,10 @@ async def get_spotify_playlist(url):
 
 def get_url(content):
 
-    regex = compile(
+    regex = re.compile(
         "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 
-    if search(regex, content):
+    if re.search(regex, content):
         result = regex.search(content)
         url = result.group(0)
         return url

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -1,8 +1,7 @@
 from collections import deque
-import random
+from random import shuffle
 
 from config import config
-
 
 class Playlist:
     """Stores the youtube links of songs to be played and already played and offers basic operation on the queues"""
@@ -52,9 +51,7 @@ class Playlist:
 
     def prev(self):
         if len(self.playhistory) == 0:
-            dummy = "DummySong"
-            self.playque.appendleft(dummy)
-            return dummy
+            return self.playque.appendleft("DummySong")
         self.playque.appendleft(self.playhistory.pop())
         return self.playque[0]
 

--- a/musicbot/songinfo.py
+++ b/musicbot/songinfo.py
@@ -1,6 +1,6 @@
 import discord
 from config import config
-from timedelta import datetime
+from datetime import timedelta
 
 class Song():
     def __init__(self, origin, host, base_url=None, uploader=None, title=None, duration=None, webpage_url=None, thumbnail=None):

--- a/musicbot/songinfo.py
+++ b/musicbot/songinfo.py
@@ -1,8 +1,6 @@
 import discord
-from discord.ext import commands
 from config import config
-import datetime
-
+from timedelta import datetime
 
 class Song():
     def __init__(self, origin, host, base_url=None, uploader=None, title=None, duration=None, webpage_url=None, thumbnail=None):
@@ -33,7 +31,7 @@ class Song():
 
             if self.duration is not None and type(self.duration) is not float:
                 embed.add_field(name=config.SONGINFO_DURATION,
-                                value="{}".format(str(datetime.timedelta(seconds=self.duration))), inline=False)
+                                value="{}".format(str(timedelta(seconds=self.duration))), inline=False)
             else:
                 embed.add_field(name=config.SONGINFO_DURATION,
                                 value=config.SONGINFO_UNKNOWN_DURATION , inline=False)

--- a/musicbot/songinfo.py
+++ b/musicbot/songinfo.py
@@ -31,7 +31,7 @@ class Song():
             embed.add_field(name=config.SONGINFO_UPLOADER,
                             value=self.uploader, inline=False)
 
-            if self.duration is not None:
+            if self.duration is not None and type(self.duration) is not float:
                 embed.add_field(name=config.SONGINFO_DURATION,
                                 value="{}".format(str(datetime.timedelta(seconds=self.duration))), inline=False)
             else:


### PR DESCRIPTION
Fixed an issue that livestreams would appear as 00:00:00 duration inside the embed, this will now be 'unkown', or what you got as SONGINFO_UNKNOWN_DURATION in your config.