### PR TITLE
Catch guild register error

### DIFF
--- a/musicbot/settings.py
+++ b/musicbot/settings.py
@@ -161,7 +161,11 @@ class Settings():
             return False
         else:
             self.config[setting] = value
-            await self.guild.me.edit(nick=value)
+            try:
+                await self.guild.me.edit(nick=value)
+            except:
+                await ctx.send("`Error: Cannot set nickname. Please check bot permissions.")
+
 
     async def command_channel(self, setting, value, ctx):
 

--- a/run.py
+++ b/run.py
@@ -58,7 +58,10 @@ async def register(guild):
 
     sett = guild_to_settings[guild]
 
-    await guild.me.edit(nick=sett.get('default_nickname'))
+    try:
+        await guild.me.edit(nick=sett.get('default_nickname'))
+    except:
+        pass
 
     if config.GLOBAL_DISABLE_AUTOJOIN_VC == True:
         return


### PR DESCRIPTION
Nickname uncaught would stop the register function from completing.